### PR TITLE
include name in errors to make them easier to find.

### DIFF
--- a/src/ConnectionArgFilterPlugin.js
+++ b/src/ConnectionArgFilterPlugin.js
@@ -28,13 +28,13 @@ module.exports = function ConnectionArgFilterPlugin(
           throw new Error("No filter operator name specified");
         }
         if (connectionFilterOperators[name]) {
-          throw new Error("There is already a filter operator with this name");
+          throw new Error("There is already a filter operator with the name '" + name + "'");
         }
         if (!resolveType) {
-          throw new Error("No filter operator type specified");
+          throw new Error("No filter operator type specified for '" + name + "'");
         }
         if (!resolveWhereClause) {
-          throw new Error("No filter operator where clause resolver specified");
+          throw new Error("No filter operator where clause resolver specified for '" + name + "'");
         }
         connectionFilterOperators[name] = {
           name,


### PR DESCRIPTION
Just as it says on the tin.  I caused one of these when adding the new inverse items and it was caught in the test run, but it wouldn't tell me which one was being duplicated.