### PR TITLE
Add inverse operators

### DIFF
--- a/__tests__/fixtures/queries/connections-filter.graphql
+++ b/__tests__/fixtures/queries/connections-filter.graphql
@@ -1,24 +1,32 @@
 query {
-  a: allPeople(filter: { about: { null: true } }) { ...personConnection }
-  b: allPeople(filter: { about: { null: false } }) { ...personConnection }
-  c: allPeople(filter: { about: { equalTo: "Just a friendly human" } }) { ...personConnection }
-  d: allPeople(filter: { about: { notEqualTo: "Just a friendly human" } }) { ...personConnection }
-  e: allPeople(filter: { about: { distinctFrom: "Just a friendly human" } }) { ...personConnection }
-  f: allPeople(filter: { about: { notDistinctFrom: "Just a friendly human" } }) { ...personConnection }
-  g: allPeople(filter: { id: { lessThan: 3 } }) { ...personConnection }
-  h: allPeople(filter: { id: { lessThanOrEqualTo: 3 } }) { ...personConnection }
-  i: allPeople(filter: { id: { greaterThan: 3 } }) { ...personConnection }
-  j: allPeople(filter: { id: { greaterThanOrEqualTo: 3 } }) { ...personConnection }
-  k: allPeople(filter: { id: { in: [3, 4] } }) { ...personConnection }
-  l: allPeople(filter: { id: { notIn: [3, 4] } }) { ...personConnection }
-  m: allPeople(filter: { name: { contains: "Seven" } }) { ...personConnection }
-  n: allPeople(filter: { name: { containsInsensitive: "seven" } }) { ...personConnection }
-  o: allPeople(filter: { name: { startsWith: "Joe" } }) { ...personConnection }
-  p: allPeople(filter: { name: { startsWithInsensitive: "joe" } }) { ...personConnection }
-  q: allPeople(filter: { name: { endsWith: "Smith" } }) { ...personConnection }
-  r: allPeople(filter: { name: { endsWithInsensitive: "smith" } }) { ...personConnection }
-  s: allPeople(filter: { name: { like: "J%Smith" } }) { ...personConnection }
-  t: allPeople(filter: { name: { likeInsensitive: "j%smith" } }) { ...personConnection }
+  aa: allPeople(filter: { about: { null: true } }) { ...personConnection }
+  ab: allPeople(filter: { about: { null: false } }) { ...personConnection }
+  ac: allPeople(filter: { about: { equalTo: "Just a friendly human" } }) { ...personConnection }
+  ad: allPeople(filter: { about: { notEqualTo: "Just a friendly human" } }) { ...personConnection }
+  ae: allPeople(filter: { about: { distinctFrom: "Just a friendly human" } }) { ...personConnection }
+  af: allPeople(filter: { about: { notDistinctFrom: "Just a friendly human" } }) { ...personConnection }
+  ag: allPeople(filter: { id: { lessThan: 3 } }) { ...personConnection }
+  ah: allPeople(filter: { id: { lessThanOrEqualTo: 3 } }) { ...personConnection }
+  ai: allPeople(filter: { id: { greaterThan: 3 } }) { ...personConnection }
+  aj: allPeople(filter: { id: { greaterThanOrEqualTo: 3 } }) { ...personConnection }
+  ak: allPeople(filter: { id: { in: [3, 4] } }) { ...personConnection }
+  al: allPeople(filter: { id: { notIn: [3, 4] } }) { ...personConnection }
+  am: allPeople(filter: { name: { contains: "Seven" } }) { ...personConnection }
+  an: allPeople(filter: { name: { containsInsensitive: "seven" } }) { ...personConnection }
+  ao: allPeople(filter: { name: { startsWith: "Joe" } }) { ...personConnection }
+  ap: allPeople(filter: { name: { startsWithInsensitive: "joe" } }) { ...personConnection }
+  aq: allPeople(filter: { name: { endsWith: "Smith" } }) { ...personConnection }
+  ar: allPeople(filter: { name: { endsWithInsensitive: "smith" } }) { ...personConnection }
+  as: allPeople(filter: { name: { like: "J%Smith" } }) { ...personConnection }
+  at: allPeople(filter: { name: { likeInsensitive: "j%smith" } }) { ...personConnection }
+  au: allPeople(filter: { name: { notContains: "Smit"} }) { ...personConnection }
+  av: allPeople(filter: { name: { notContainsInsensitive: "smit"} }) { ...personConnection }
+  aw: allPeople(filter: { name: { notStartsWith: "Joe" } }) { ...personConnection }
+  ax: allPeople(filter: { name: { notStartsWithInsensitive: "joe" } }) { ...personConnection }
+  ay: allPeople(filter: { name: { notEndsWith: "Smith" } }) { ...personConnection }
+  az: allPeople(filter: { name: { notEndsWithInsensitive: "smith" } }) { ...personConnection }
+  ba: allPeople(filter: { name: { notLike: "J%Smith" } }) { ...personConnection }
+  bb: allPeople(filter: { name: { notLikeInsensitive: "j%smith" } }) { ...personConnection }
 }
 
 fragment personConnection on PeopleConnection {

--- a/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -53,14 +53,22 @@ Object {
             "name": "Twenty Seventwo",
           },
         },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
+          },
+        },
       ],
       "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
         "hasNextPage": false,
         "hasPreviousPage": false,
         "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
       },
-      "totalCount": 6,
+      "totalCount": 7,
     },
     "b": Object {
       "edges": Array [
@@ -87,18 +95,10 @@ Object {
         "hasPreviousPage": false,
         "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
       },
-      "totalCount": 6,
+      "totalCount": 7,
     },
     "c": Object {
       "edges": Array [
-        Object {
-          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
-          "node": Object {
-            "email": "joe.tucker@email.com",
-            "id": 5,
-            "name": "Joe Tucker",
-          },
-        },
         Object {
           "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
           "node": Object {
@@ -107,14 +107,22 @@ Object {
             "name": "Twenty Seventwo",
           },
         },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
+          },
+        },
       ],
       "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
         "hasNextPage": false,
         "hasPreviousPage": true,
-        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
       },
-      "totalCount": 6,
+      "totalCount": 7,
     },
     "d": Object {
       "edges": Array [
@@ -166,17 +174,33 @@ Object {
             "name": "Twenty Seventwo",
           },
         },
+        Object {
+          "cursor": "WyJuYW1lX2FzYyIsWyJqYW1lcyBzbWl0aCIsN11d",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
+          },
+        },
       ],
       "pageInfo": Object {
-        "endCursor": "WyJuYW1lX2FzYyIsWyJUd2VudHkgU2V2ZW50d28iLDZdXQ==",
+        "endCursor": "WyJuYW1lX2FzYyIsWyJqYW1lcyBzbWl0aCIsN11d",
         "hasNextPage": false,
         "hasPreviousPage": false,
         "startCursor": "WyJuYW1lX2FzYyIsWyJCdWRkIERlZXkiLDNdXQ==",
       },
-      "totalCount": 6,
+      "totalCount": 7,
     },
     "e": Object {
       "edges": Array [
+        Object {
+          "cursor": "WyJuYW1lX2Rlc2MiLFsiamFtZXMgc21pdGgiLDddXQ==",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
+          },
+        },
         Object {
           "cursor": "WyJuYW1lX2Rlc2MiLFsiVHdlbnR5IFNldmVudHdvIiw2XV0=",
           "node": Object {
@@ -230,9 +254,9 @@ Object {
         "endCursor": "WyJuYW1lX2Rlc2MiLFsiQnVkZCBEZWV5IiwzXV0=",
         "hasNextPage": false,
         "hasPreviousPage": false,
-        "startCursor": "WyJuYW1lX2Rlc2MiLFsiVHdlbnR5IFNldmVudHdvIiw2XV0=",
+        "startCursor": "WyJuYW1lX2Rlc2MiLFsiamFtZXMgc21pdGgiLDddXQ==",
       },
-      "totalCount": 6,
+      "totalCount": 7,
     },
     "f": Object {
       "edges": Array [
@@ -251,7 +275,7 @@ Object {
         "hasPreviousPage": false,
         "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
       },
-      "totalCount": 6,
+      "totalCount": 7,
     },
     "g": Object {
       "edges": Array [
@@ -287,14 +311,22 @@ Object {
             "name": "Twenty Seventwo",
           },
         },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
+          },
+        },
       ],
       "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
         "hasNextPage": false,
         "hasPreviousPage": true,
         "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
       },
-      "totalCount": 6,
+      "totalCount": 7,
     },
     "h": Object {
       "edges": Array [
@@ -344,6 +376,14 @@ Object {
             "constant": 2,
             "name": "Twenty Seventwo",
             "x": 6,
+          },
+        },
+        Object {
+          "cursor": "WyJuYXR1cmFsIiw3XQ==",
+          "node": Object {
+            "constant": 2,
+            "name": "james smith",
+            "x": 7,
           },
         },
       ],
@@ -396,6 +436,14 @@ Object {
             "constant": 2,
             "name": "Twenty Seventwo",
             "x": 6,
+          },
+        },
+        Object {
+          "cursor": "WyJjb25zdGFudF9hc2MiLFsyXV0=",
+          "node": Object {
+            "constant": 2,
+            "name": "james smith",
+            "x": 7,
           },
         },
       ],
@@ -508,7 +556,7 @@ Object {
         "hasPreviousPage": true,
         "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
       },
-      "totalCount": 6,
+      "totalCount": 7,
     },
     "n": Object {
       "edges": Array [],
@@ -518,7 +566,7 @@ Object {
         "hasPreviousPage": false,
         "startCursor": null,
       },
-      "totalCount": 6,
+      "totalCount": 7,
     },
     "o": Object {
       "nodes": Array [
@@ -552,7 +600,7 @@ Object {
         "hasPreviousPage": true,
         "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
       },
-      "totalCount": 6,
+      "totalCount": 7,
     },
     "q": Object {
       "edges": Array [
@@ -571,26 +619,26 @@ Object {
         "hasPreviousPage": true,
         "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
       },
-      "totalCount": 6,
+      "totalCount": 7,
     },
     "r": Object {
       "edges": Array [
         Object {
-          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
           "node": Object {
-            "email": "graphile-build.issue.27.exists@example.com",
-            "id": 6,
-            "name": "Twenty Seventwo",
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
           },
         },
       ],
       "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
         "hasNextPage": false,
         "hasPreviousPage": true,
-        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
       },
-      "totalCount": 6,
+      "totalCount": 7,
     },
   },
 }
@@ -599,7 +647,7 @@ Object {
 exports[`connections-filter.graphql 1`] = `
 Object {
   "data": Object {
-    "a": Object {
+    "aa": Object {
       "edges": Array [
         Object {
           "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
@@ -641,16 +689,24 @@ Object {
             "name": "Twenty Seventwo",
           },
         },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
+          },
+        },
       ],
       "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
         "hasNextPage": false,
         "hasPreviousPage": false,
         "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
       },
-      "totalCount": 5,
+      "totalCount": 6,
     },
-    "b": Object {
+    "ab": Object {
       "edges": Array [
         Object {
           "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
@@ -669,7 +725,7 @@ Object {
       },
       "totalCount": 1,
     },
-    "c": Object {
+    "ac": Object {
       "edges": Array [
         Object {
           "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
@@ -688,7 +744,7 @@ Object {
       },
       "totalCount": 1,
     },
-    "d": Object {
+    "ad": Object {
       "edges": Array [],
       "pageInfo": Object {
         "endCursor": null,
@@ -698,7 +754,7 @@ Object {
       },
       "totalCount": 0,
     },
-    "e": Object {
+    "ae": Object {
       "edges": Array [
         Object {
           "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
@@ -740,16 +796,24 @@ Object {
             "name": "Twenty Seventwo",
           },
         },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
+          },
+        },
       ],
       "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
         "hasNextPage": false,
         "hasPreviousPage": false,
         "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
       },
-      "totalCount": 5,
+      "totalCount": 6,
     },
-    "f": Object {
+    "af": Object {
       "edges": Array [
         Object {
           "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
@@ -768,7 +832,7 @@ Object {
       },
       "totalCount": 1,
     },
-    "g": Object {
+    "ag": Object {
       "edges": Array [
         Object {
           "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
@@ -795,7 +859,7 @@ Object {
       },
       "totalCount": 2,
     },
-    "h": Object {
+    "ah": Object {
       "edges": Array [
         Object {
           "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
@@ -830,7 +894,7 @@ Object {
       },
       "totalCount": 3,
     },
-    "i": Object {
+    "ai": Object {
       "edges": Array [
         Object {
           "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
@@ -856,16 +920,24 @@ Object {
             "name": "Twenty Seventwo",
           },
         },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
+          },
+        },
       ],
       "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
         "hasNextPage": false,
         "hasPreviousPage": false,
         "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
       },
-      "totalCount": 3,
+      "totalCount": 4,
     },
-    "j": Object {
+    "aj": Object {
       "edges": Array [
         Object {
           "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
@@ -899,16 +971,24 @@ Object {
             "name": "Twenty Seventwo",
           },
         },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
+          },
+        },
       ],
       "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
         "hasNextPage": false,
         "hasPreviousPage": false,
         "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
       },
-      "totalCount": 4,
+      "totalCount": 5,
     },
-    "k": Object {
+    "ak": Object {
       "edges": Array [
         Object {
           "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
@@ -935,7 +1015,7 @@ Object {
       },
       "totalCount": 2,
     },
-    "l": Object {
+    "al": Object {
       "edges": Array [
         Object {
           "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
@@ -969,92 +1049,302 @@ Object {
             "name": "Twenty Seventwo",
           },
         },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+      },
+      "totalCount": 5,
+    },
+    "am": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+          "node": Object {
+            "email": "graphile-build.issue.27.exists@example.com",
+            "id": 6,
+            "name": "Twenty Seventwo",
+          },
+        },
       ],
       "pageInfo": Object {
         "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
         "hasNextPage": false,
         "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+      },
+      "totalCount": 1,
+    },
+    "an": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+          "node": Object {
+            "email": "graphile-build.issue.27.exists@example.com",
+            "id": 6,
+            "name": "Twenty Seventwo",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+      },
+      "totalCount": 1,
+    },
+    "ao": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+          "node": Object {
+            "email": "joe.tucker@email.com",
+            "id": 5,
+            "name": "Joe Tucker",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+      },
+      "totalCount": 1,
+    },
+    "ap": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+          "node": Object {
+            "email": "joe.tucker@email.com",
+            "id": 5,
+            "name": "Joe Tucker",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+      },
+      "totalCount": 1,
+    },
+    "aq": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+          "node": Object {
+            "email": "john.smith@email.com",
+            "id": 1,
+            "name": "John Smith",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
+          "node": Object {
+            "email": "sara.smith@email.com",
+            "id": 2,
+            "name": "Sara Smith",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
         "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+      },
+      "totalCount": 2,
+    },
+    "ar": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+          "node": Object {
+            "email": "john.smith@email.com",
+            "id": 1,
+            "name": "John Smith",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
+          "node": Object {
+            "email": "sara.smith@email.com",
+            "id": 2,
+            "name": "Sara Smith",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+      },
+      "totalCount": 3,
+    },
+    "as": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+          "node": Object {
+            "email": "john.smith@email.com",
+            "id": 1,
+            "name": "John Smith",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+      },
+      "totalCount": 1,
+    },
+    "at": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+          "node": Object {
+            "email": "john.smith@email.com",
+            "id": 1,
+            "name": "John Smith",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+      },
+      "totalCount": 2,
+    },
+    "au": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
+          "node": Object {
+            "email": "budd.deey@email.com",
+            "id": 3,
+            "name": "Budd Deey",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
+          "node": Object {
+            "email": "kathryn.ramirez@email.com",
+            "id": 4,
+            "name": "Kathryn Ramirez",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+          "node": Object {
+            "email": "joe.tucker@email.com",
+            "id": 5,
+            "name": "Joe Tucker",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+          "node": Object {
+            "email": "graphile-build.issue.27.exists@example.com",
+            "id": 6,
+            "name": "Twenty Seventwo",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
+      },
+      "totalCount": 5,
+    },
+    "av": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
+          "node": Object {
+            "email": "budd.deey@email.com",
+            "id": 3,
+            "name": "Budd Deey",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
+          "node": Object {
+            "email": "kathryn.ramirez@email.com",
+            "id": 4,
+            "name": "Kathryn Ramirez",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+          "node": Object {
+            "email": "joe.tucker@email.com",
+            "id": 5,
+            "name": "Joe Tucker",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+          "node": Object {
+            "email": "graphile-build.issue.27.exists@example.com",
+            "id": 6,
+            "name": "Twenty Seventwo",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
       },
       "totalCount": 4,
     },
-    "m": Object {
-      "edges": Array [
-        Object {
-          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
-          "node": Object {
-            "email": "graphile-build.issue.27.exists@example.com",
-            "id": 6,
-            "name": "Twenty Seventwo",
-          },
-        },
-      ],
-      "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
-        "hasNextPage": false,
-        "hasPreviousPage": false,
-        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
-      },
-      "totalCount": 1,
-    },
-    "n": Object {
-      "edges": Array [
-        Object {
-          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
-          "node": Object {
-            "email": "graphile-build.issue.27.exists@example.com",
-            "id": 6,
-            "name": "Twenty Seventwo",
-          },
-        },
-      ],
-      "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
-        "hasNextPage": false,
-        "hasPreviousPage": false,
-        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
-      },
-      "totalCount": 1,
-    },
-    "o": Object {
-      "edges": Array [
-        Object {
-          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
-          "node": Object {
-            "email": "joe.tucker@email.com",
-            "id": 5,
-            "name": "Joe Tucker",
-          },
-        },
-      ],
-      "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
-        "hasNextPage": false,
-        "hasPreviousPage": false,
-        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
-      },
-      "totalCount": 1,
-    },
-    "p": Object {
-      "edges": Array [
-        Object {
-          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
-          "node": Object {
-            "email": "joe.tucker@email.com",
-            "id": 5,
-            "name": "Joe Tucker",
-          },
-        },
-      ],
-      "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
-        "hasNextPage": false,
-        "hasPreviousPage": false,
-        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
-      },
-      "totalCount": 1,
-    },
-    "q": Object {
+    "aw": Object {
       "edges": Array [
         Object {
           "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
@@ -1072,16 +1362,48 @@ Object {
             "name": "Sara Smith",
           },
         },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
+          "node": Object {
+            "email": "budd.deey@email.com",
+            "id": 3,
+            "name": "Budd Deey",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
+          "node": Object {
+            "email": "kathryn.ramirez@email.com",
+            "id": 4,
+            "name": "Kathryn Ramirez",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+          "node": Object {
+            "email": "graphile-build.issue.27.exists@example.com",
+            "id": 6,
+            "name": "Twenty Seventwo",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
+          },
+        },
       ],
       "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
         "hasNextPage": false,
         "hasPreviousPage": false,
         "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
       },
-      "totalCount": 2,
+      "totalCount": 6,
     },
-    "r": Object {
+    "ax": Object {
       "edges": Array [
         Object {
           "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
@@ -1099,52 +1421,250 @@ Object {
             "name": "Sara Smith",
           },
         },
-      ],
-      "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
-        "hasNextPage": false,
-        "hasPreviousPage": false,
-        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
-      },
-      "totalCount": 2,
-    },
-    "s": Object {
-      "edges": Array [
         Object {
-          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
           "node": Object {
-            "email": "john.smith@email.com",
-            "id": 1,
-            "name": "John Smith",
+            "email": "budd.deey@email.com",
+            "id": 3,
+            "name": "Budd Deey",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
+          "node": Object {
+            "email": "kathryn.ramirez@email.com",
+            "id": 4,
+            "name": "Kathryn Ramirez",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+          "node": Object {
+            "email": "graphile-build.issue.27.exists@example.com",
+            "id": 6,
+            "name": "Twenty Seventwo",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
           },
         },
       ],
       "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
         "hasNextPage": false,
         "hasPreviousPage": false,
         "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
       },
-      "totalCount": 1,
+      "totalCount": 6,
     },
-    "t": Object {
+    "ay": Object {
       "edges": Array [
         Object {
-          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
           "node": Object {
-            "email": "john.smith@email.com",
-            "id": 1,
-            "name": "John Smith",
+            "email": "budd.deey@email.com",
+            "id": 3,
+            "name": "Budd Deey",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
+          "node": Object {
+            "email": "kathryn.ramirez@email.com",
+            "id": 4,
+            "name": "Kathryn Ramirez",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+          "node": Object {
+            "email": "joe.tucker@email.com",
+            "id": 5,
+            "name": "Joe Tucker",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+          "node": Object {
+            "email": "graphile-build.issue.27.exists@example.com",
+            "id": 6,
+            "name": "Twenty Seventwo",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
           },
         },
       ],
       "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
         "hasNextPage": false,
         "hasPreviousPage": false,
-        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
       },
-      "totalCount": 1,
+      "totalCount": 5,
+    },
+    "az": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
+          "node": Object {
+            "email": "budd.deey@email.com",
+            "id": 3,
+            "name": "Budd Deey",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
+          "node": Object {
+            "email": "kathryn.ramirez@email.com",
+            "id": 4,
+            "name": "Kathryn Ramirez",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+          "node": Object {
+            "email": "joe.tucker@email.com",
+            "id": 5,
+            "name": "Joe Tucker",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+          "node": Object {
+            "email": "graphile-build.issue.27.exists@example.com",
+            "id": 6,
+            "name": "Twenty Seventwo",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
+      },
+      "totalCount": 4,
+    },
+    "ba": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
+          "node": Object {
+            "email": "sara.smith@email.com",
+            "id": 2,
+            "name": "Sara Smith",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
+          "node": Object {
+            "email": "budd.deey@email.com",
+            "id": 3,
+            "name": "Budd Deey",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
+          "node": Object {
+            "email": "kathryn.ramirez@email.com",
+            "id": 4,
+            "name": "Kathryn Ramirez",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+          "node": Object {
+            "email": "joe.tucker@email.com",
+            "id": 5,
+            "name": "Joe Tucker",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+          "node": Object {
+            "email": "graphile-build.issue.27.exists@example.com",
+            "id": 6,
+            "name": "Twenty Seventwo",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+          "node": Object {
+            "email": "james.smith@email.com",
+            "id": 7,
+            "name": "james smith",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs3XV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
+      },
+      "totalCount": 6,
+    },
+    "bb": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
+          "node": Object {
+            "email": "sara.smith@email.com",
+            "id": 2,
+            "name": "Sara Smith",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
+          "node": Object {
+            "email": "budd.deey@email.com",
+            "id": 3,
+            "name": "Budd Deey",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
+          "node": Object {
+            "email": "kathryn.ramirez@email.com",
+            "id": 4,
+            "name": "Kathryn Ramirez",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+          "node": Object {
+            "email": "joe.tucker@email.com",
+            "id": 5,
+            "name": "Joe Tucker",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+          "node": Object {
+            "email": "graphile-build.issue.27.exists@example.com",
+            "id": 6,
+            "name": "Twenty Seventwo",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs2XV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
+      },
+      "totalCount": 5,
     },
   },
 }

--- a/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -3315,7 +3315,7 @@ enum SimilarTable2SOrderBy {
 
 # A filter to be used against String fields. All fields are combined with a logical ‘and.’
 input StringFilter {
-  # Checks for strings containing this string.  Case sensitive.
+  # Checks for strings containing this value.  Case sensitive.
   contains: String
 
   # Checks for strings containing this value.  Case insensitive.
@@ -3324,10 +3324,10 @@ input StringFilter {
   # Checks for values not equal to this value, treating null like an ordinary value.
   distinctFrom: String
 
-  # Checks for strings ending with this string.  Case sensitive.
+  # Checks for strings ending with this value.  Case sensitive.
   endsWith: String
 
-  # Checks for strings ending with this string.  Case insensitive.
+  # Checks for strings ending with this value.  Case insensitive.
   endsWithInsensitive: String
 
   # Checks for values equal to this value.
@@ -3354,8 +3354,20 @@ input StringFilter {
   # Raw SQL 'ilike', wildcards must be present and are not escaped
   likeInsensitive: String
 
+  # Checks for strings that do not contain this value.  Case sensitive.
+  notContains: String
+
+  # Checks for strings that do not not contain this value.  Case insensitive.
+  notContainsInsensitive: String
+
   # Checks for values equal to this value, treating null like an ordinary value.
   notDistinctFrom: String
+
+  # Checks for strings that do not end with this value.  Case sensitive.
+  notEndsWith: String
+
+  # Checks for strings that do not end with this value.  Case insensitive.
+  notEndsWithInsensitive: String
 
   # Checks for values not equal to this value.
   notEqualTo: String
@@ -3363,13 +3375,25 @@ input StringFilter {
   # Checks for values not in this list.
   notIn: [String!]
 
+  # Raw SQL 'not like', wildcards must be present and are not escaped
+  notLike: String
+
+  # Raw SQL 'not ilike', wildcards must be present and are not escaped
+  notLikeInsensitive: String
+
+  # Checks for strings that do not start with this value.  Case sensitive.
+  notStartsWith: String
+
+  # Checks for strings that do not start with this value.  Case insensitive.
+  notStartsWithInsensitive: String
+
   # If set to true, checks for null values.  If set to false, checks for non-null values.
   null: Boolean
 
-  # Checks for strings starting with this string.  Case sensitive.
+  # Checks for strings starting with this value.  Case sensitive.
   startsWith: String
 
-  # Checks for strings starting with this string.  Case insensitive.
+  # Checks for strings starting with this value.  Case insensitive.
   startsWithInsensitive: String
 }
 

--- a/__tests__/kitchen-sink-data.sql
+++ b/__tests__/kitchen-sink-data.sql
@@ -4,7 +4,8 @@ insert into c.person (id, name, email, about, created_at) values
   (3, 'Budd Deey', 'budd.deey@email.com', 'Just a friendly human', null),
   (4, 'Kathryn Ramirez', 'kathryn.ramirez@email.com', null, null),
   (5, 'Joe Tucker', 'joe.tucker@email.com', null, null),
-  (6, 'Twenty Seventwo', 'graphile-build.issue.27.exists@example.com', null, null);
+  (6, 'Twenty Seventwo', 'graphile-build.issue.27.exists@example.com', null, null),
+  (7, 'james smith', 'james.smith@email.com', null, null);
 
 alter sequence c.person_id_seq restart with 10;
 

--- a/src/PgConnectionArgFilterOperatorsPlugin.js
+++ b/src/PgConnectionArgFilterOperatorsPlugin.js
@@ -167,10 +167,22 @@ module.exports = function PgConnectionArgFilterOperatorsPlugin(
       );
       addConnectionFilterOperator(
         connectionFilterUsesShortNames ? "cont" : "contains",
-        "Checks for strings containing this string.  Case sensitive.",
+        "Checks for strings containing this value.  Case sensitive.",
         typeName => getTypeByName(typeName),
         (identifier, val) => {
-          return sql.query`${identifier} like ${val}`;
+          return sql.query`${identifier} LIKE ${val}`;
+        },
+        {
+          allowedFieldTypes: ["String"],
+          inputResolver: input => `%${escapeLikeWildcards(input)}%`,
+        }
+      );
+      addConnectionFilterOperator(
+        connectionFilterUsesShortNames ? "ncont" : "notContains",
+        "Checks for strings that do not contain this value.  Case sensitive.",
+        typeName => getTypeByName(typeName),
+        (identifier, val) => {
+          return sql.query`${identifier} NOT LIKE ${val}`;
         },
         {
           allowedFieldTypes: ["String"],
@@ -182,7 +194,19 @@ module.exports = function PgConnectionArgFilterOperatorsPlugin(
         "Checks for strings containing this value.  Case insensitive.",
         typeName => getTypeByName(typeName),
         (identifier, val) => {
-          return sql.query`${identifier} ilike ${val}`;
+          return sql.query`${identifier} ILIKE ${val}`;
+        },
+        {
+          allowedFieldTypes: ["String"],
+          inputResolver: input => `%${escapeLikeWildcards(input)}%`,
+        }
+      );
+      addConnectionFilterOperator(
+        connectionFilterUsesShortNames ? "nconti" : "notContainsInsensitive",
+        "Checks for strings that do not not contain this value.  Case insensitive.",
+        typeName => getTypeByName(typeName),
+        (identifier, val) => {
+          return sql.query`${identifier} NOT ILIKE ${val}`;
         },
         {
           allowedFieldTypes: ["String"],
@@ -191,10 +215,22 @@ module.exports = function PgConnectionArgFilterOperatorsPlugin(
       );
       addConnectionFilterOperator(
         connectionFilterUsesShortNames ? "starts" : "startsWith",
-        "Checks for strings starting with this string.  Case sensitive.",
+        "Checks for strings starting with this value.  Case sensitive.",
         typeName => getTypeByName(typeName),
         (identifier, val) => {
-          return sql.query`${identifier} like ${val}`;
+          return sql.query`${identifier} LIKE ${val}`;
+        },
+        {
+          allowedFieldTypes: ["String"],
+          inputResolver: input => `${escapeLikeWildcards(input)}%`,
+        }
+      );
+      addConnectionFilterOperator(
+        connectionFilterUsesShortNames ? "nstarts" : "notStartsWith",
+        "Checks for strings that do not start with this value.  Case sensitive.",
+        typeName => getTypeByName(typeName),
+        (identifier, val) => {
+          return sql.query`${identifier} NOT LIKE ${val}`;
         },
         {
           allowedFieldTypes: ["String"],
@@ -203,10 +239,22 @@ module.exports = function PgConnectionArgFilterOperatorsPlugin(
       );
       addConnectionFilterOperator(
         connectionFilterUsesShortNames ? "startsi" : "startsWithInsensitive",
-        "Checks for strings starting with this string.  Case insensitive.",
+        "Checks for strings starting with this value.  Case insensitive.",
         typeName => getTypeByName(typeName),
         (identifier, val) => {
-          return sql.query`${identifier} ilike ${val}`;
+          return sql.query`${identifier} ILIKE ${val}`;
+        },
+        {
+          allowedFieldTypes: ["String"],
+          inputResolver: input => `${escapeLikeWildcards(input)}%`,
+        }
+      );
+      addConnectionFilterOperator(
+        connectionFilterUsesShortNames ? "nstartsi" : "notStartsWithInsensitive",
+        "Checks for strings that do not start with this value.  Case insensitive.",
+        typeName => getTypeByName(typeName),
+        (identifier, val) => {
+          return sql.query`${identifier} NOT ILIKE ${val}`;
         },
         {
           allowedFieldTypes: ["String"],
@@ -215,10 +263,22 @@ module.exports = function PgConnectionArgFilterOperatorsPlugin(
       );
       addConnectionFilterOperator(
         connectionFilterUsesShortNames ? "ends" : "endsWith",
-        "Checks for strings ending with this string.  Case sensitive.",
+        "Checks for strings ending with this value.  Case sensitive.",
         typeName => getTypeByName(typeName),
         (identifier, val) => {
-          return sql.query`${identifier} like ${val}`;
+          return sql.query`${identifier} LIKE ${val}`;
+        },
+        {
+          allowedFieldTypes: ["String"],
+          inputResolver: input => `%${escapeLikeWildcards(input)}`,
+        }
+      );
+      addConnectionFilterOperator(
+        connectionFilterUsesShortNames ? "nends" : "notEndsWith",
+        "Checks for strings that do not end with this value.  Case sensitive.",
+        typeName => getTypeByName(typeName),
+        (identifier, val) => {
+          return sql.query`${identifier} NOT LIKE ${val}`;
         },
         {
           allowedFieldTypes: ["String"],
@@ -227,10 +287,22 @@ module.exports = function PgConnectionArgFilterOperatorsPlugin(
       );
       addConnectionFilterOperator(
         connectionFilterUsesShortNames ? "endsi" : "endsWithInsensitive",
-        "Checks for strings ending with this string.  Case insensitive.",
+        "Checks for strings ending with this value.  Case insensitive.",
         typeName => getTypeByName(typeName),
         (identifier, val) => {
-          return sql.query`${identifier} ilike ${val}`;
+          return sql.query`${identifier} ILIKE ${val}`;
+        },
+        {
+          allowedFieldTypes: ["String"],
+          inputResolver: input => `%${escapeLikeWildcards(input)}`,
+        }
+      );
+      addConnectionFilterOperator(
+        connectionFilterUsesShortNames ? "nendsi" : "notEndsWithInsensitive",
+        "Checks for strings that do not end with this value.  Case insensitive.",
+        typeName => getTypeByName(typeName),
+        (identifier, val) => {
+          return sql.query`${identifier} NOT ILIKE ${val}`;
         },
         {
           allowedFieldTypes: ["String"],
@@ -242,7 +314,18 @@ module.exports = function PgConnectionArgFilterOperatorsPlugin(
         "Raw SQL 'like', wildcards must be present and are not escaped",
         typeName => getTypeByName(typeName),
         (identifier, val) => {
-          return sql.query`${identifier} like ${val}`;
+          return sql.query`${identifier} LIKE ${val}`;
+        },
+        {
+          allowedFieldTypes: ["String"],
+        }
+      );
+      addConnectionFilterOperator(
+        connectionFilterUsesShortNames ? "nlike" : "notLike",
+        "Raw SQL 'not like', wildcards must be present and are not escaped",
+        typeName => getTypeByName(typeName),
+        (identifier, val) => {
+          return sql.query`${identifier} NOT LIKE ${val}`;
         },
         {
           allowedFieldTypes: ["String"],
@@ -253,7 +336,18 @@ module.exports = function PgConnectionArgFilterOperatorsPlugin(
         "Raw SQL 'ilike', wildcards must be present and are not escaped",
         typeName => getTypeByName(typeName),
         (identifier, val) => {
-          return sql.query`${identifier} ilike ${val}`;
+          return sql.query`${identifier} ILIKE ${val}`;
+        },
+        {
+          allowedFieldTypes: ["String"],
+        }
+      );
+      addConnectionFilterOperator(
+        connectionFilterUsesShortNames ? "nilike" : "notLikeInsensitive",
+        "Raw SQL 'not ilike', wildcards must be present and are not escaped",
+        typeName => getTypeByName(typeName),
+        (identifier, val) => {
+          return sql.query`${identifier} NOT ILIKE ${val}`;
         },
         {
           allowedFieldTypes: ["String"],


### PR DESCRIPTION
As discussed in the previous PR, here is a new one that adds inverse operators for the case sensitive and insensitive versions of contains, startswith, endswith, and like.  I also reworded some graphiql hints a bit and capitalized all the SQL that I'd left lower case, after seeing that the previous filters were upper case.

I think that if this PR and the other one I sent today are both taken, that the test snapshots will have to be regenerated, since both of them modify the snapshots.